### PR TITLE
feat: add media query to reset nav state on medium screens

### DIFF
--- a/src/styles/utilities.scss
+++ b/src/styles/utilities.scss
@@ -35,3 +35,13 @@ input#nav-toggle:checked + label #hide-button {
 input#nav-toggle:checked ~ #nav-menu {
   @apply block;
 }
+
+// Reset nav state on medium screens and above
+@media (min-width: 768px) {
+  input#nav-toggle:checked ~ #nav-menu {
+    @apply flex;
+  }
+  #nav-menu {
+    @apply flex;
+  }
+}


### PR DESCRIPTION
Fix issue where mobile navigation menu remains in vertical/block state when transitioning from mobile to medium/desktop screen sizes.